### PR TITLE
Unparse instructions

### DIFF
--- a/src/iris/Makefile
+++ b/src/iris/Makefile
@@ -3,8 +3,8 @@
 
 include config.mk
 
-SRC = iris.c
-OBJ = ${SRC:.c=.o}
+SRCS = $(wildcard *.c)
+OBJS = ${SRCS:.c=.o}
 
 all: options iris
 
@@ -15,18 +15,18 @@ options:
 	@echo "CC       = ${CC}"
 
 .c.o:
-	@echo CC -c $<
-	@${CC} -c $< ${CFLAGS}
+	@echo CC -c ${SRCS}
+	@${CC} -c ${SRCS} ${CFLAGS}
 
 ${OBJ}: config.mk 
 
-iris: iris.o
-	@echo CC -o $@
-	@${CC} -o $@ iris.o ${LDFLAGS}
+iris: ${OBJS}
+	@echo CC ${OBJS} -o iris
+	@${CC} ${OBJS} -o iris ${LDFLAGS}
 
 clean:
 	@echo cleaning
-	@rm -f iris stest ${OBJ} iris-${VERSION}.tar.gz
+	@rm -f iris stest ${OBJS} iris-${VERSION}.tar.gz
 
 
 .PHONY: all options clean

--- a/src/iris/Makefile
+++ b/src/iris/Makefile
@@ -43,6 +43,11 @@ test_mnemonic: iris.o mnemonic.o tests/mnemonic.o
 	@${CC} ${LDFLAGS} -o iris iris.o mnemonic.o tests/mnemonic.o
 	@echo done.
 
+test_unparse: iris.o mnemonic.o unparse.o tests/unparse.o
+	@echo -n Building iris binary out of iris.o mnemonic.o unparse.o tests/unparse.o...
+	@${CC} ${LDFLAGS} -o iris iris.o mnemonic.o unparse.o tests/unparse.o
+	@echo done.
+
 clean:
 	@echo -n Cleaning...
 	@rm -f ${OBJECTS} ${TARGETS} ${TEST_OBJECTS} ${TEST_TARGETS}

--- a/src/iris/Makefile
+++ b/src/iris/Makefile
@@ -38,6 +38,11 @@ test_decode: iris.o tests/decode.o
 	@${CC} ${LDFLAGS} -o iris iris.o tests/decode.o
 	@echo done.
 
+test_mnemonic: iris.o mnemonic.o tests/mnemonic.o
+	@echo -n Building iris binary out of iris.o mnemonic.o tests/mnemonic.o...
+	@${CC} ${LDFLAGS} -o iris iris.o mnemonic.o tests/mnemonic.o
+	@echo done.
+
 clean:
 	@echo -n Cleaning...
 	@rm -f ${OBJECTS} ${TARGETS} ${TEST_OBJECTS} ${TEST_TARGETS}

--- a/src/iris/Makefile
+++ b/src/iris/Makefile
@@ -3,14 +3,14 @@
 
 include config.mk
 
-# TODO SOURCES = $(wildcard *.c)
-SOURCES = iris.c sim.c
-OBJECTS = ${SOURCES:.c=.o}
-TARGETS = iris
+BINARY = iris
 
-TEST_SOURCES = $(wildcard tests/*.c)
-TEST_OBJECTS = ${TEST_SOURCES:tests/%.c=tests/%.o}
-TEST_TARGETS = ${TEST_OBJECTS:%.o=%}
+# The object file that defines main()
+MAIN = sim.o
+
+OBJECTS = $(patsubst %.c,%.o,$(filter-out sim.c,$(wildcard *.c)))
+
+TEST_OBJECTS = $(patsubst %.c,%.o,$(wildcard tests/*.c))
 
 all: options iris
 
@@ -25,32 +25,19 @@ options:
 	@${CC} ${CFLAGS} -c $< -o $@
 	@echo done.
 
-iris: iris.o sim.o
-	@echo -n Building $@ binary out of iris.o sim.o...
-	@${CC} ${LDFLAGS} -o $@ iris.o sim.o
+iris: ${MAIN} ${OBJECTS}
+	@echo -n Building ${BINARY} binary out of $^...
+	@${CC} ${LDFLAGS} -o ${BINARY} $^
 	@echo done.
 
-# TODO use some `make` magic to automatically create build targets in the same
-# pattern as below for all the TEST_TARGETS
-
-test_decode: iris.o tests/decode.o
-	@echo -n Building iris binary out of iris.o tests/decode.o...
-	@${CC} ${LDFLAGS} -o iris iris.o tests/decode.o
-	@echo done.
-
-test_mnemonic: iris.o mnemonic.o tests/mnemonic.o
-	@echo -n Building iris binary out of iris.o mnemonic.o tests/mnemonic.o...
-	@${CC} ${LDFLAGS} -o iris iris.o mnemonic.o tests/mnemonic.o
-	@echo done.
-
-test_unparse: iris.o mnemonic.o unparse.o tests/unparse.o
-	@echo -n Building iris binary out of iris.o mnemonic.o unparse.o tests/unparse.o...
-	@${CC} ${LDFLAGS} -o iris iris.o mnemonic.o unparse.o tests/unparse.o
+test_%: ${OBJECTS} tests/%.o
+	@echo -n Building ${BINARY} binary out of $^...
+	@${CC} ${LDFLAGS} -o ${BINARY} $^
 	@echo done.
 
 clean:
 	@echo -n Cleaning...
-	@rm -f ${OBJECTS} ${TARGETS} ${TEST_OBJECTS} ${TEST_TARGETS}
+	@rm -f ${BINARY} ${MAIN} ${OBJECTS} ${TEST_OBJECTS}
 	@echo done.
 
 .PHONY: all options clean

--- a/src/iris/README
+++ b/src/iris/README
@@ -1,3 +1,1 @@
 This is a simple register based architecture with a limited register count.
-
-The interpreter requires plan9port to function

--- a/src/iris/iris.c
+++ b/src/iris/iris.c
@@ -289,5 +289,5 @@ void compare(core* proc, instruction inst) {
 
 void error(char* message, int code) {
    fprintf(stderr, "%s\n", message);
-   // exit(code);
+   exit(code);
 }

--- a/src/iris/iris.c
+++ b/src/iris/iris.c
@@ -24,12 +24,18 @@ int main() {
 
 int main() {
    char unparsed[100];
-   ushort inst;
+   ushort insn;
 
-   for(inst = 0; inst < 65535; inst++) {
-      unparse(unparsed, inst);
+   for(insn = 0; insn < 65535; insn++) {
+      unparse_bitstring(unparsed, insn);
+      printf("%s : ", unparsed);
+      unparse(unparsed, insn);
       printf("%s\n", unparsed);
    }
+   unparse_bitstring(unparsed, insn);
+   printf("%s : ", unparsed);
+   unparse(unparsed, insn);
+   printf("%s\n", unparsed);
 
    return 0;
 }

--- a/src/iris/iris.c
+++ b/src/iris/iris.c
@@ -26,7 +26,7 @@ int main() {
    char unparsed[20];
    ushort inst;
 
-   for(inst = 0; inst < 65536; inst++) {
+   for(inst = 0; inst < 65535; inst++) {
       unparse(unparsed, inst);
       printf("%s\n", unparsed);
    }

--- a/src/iris/iris.c
+++ b/src/iris/iris.c
@@ -1,7 +1,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "iris.h"
+#include "unparse.h"
 
+/*
 int main() {
    core proc;
    datum d;
@@ -15,6 +17,19 @@ int main() {
    decode(&proc, d.value);
    printf("equality = %d\n", proc.predicateregister);
    printf("sizeof(instruction) = %ld\n", sizeof(instruction));
+
+   return 0;
+}
+*/
+
+int main() {
+   char unparsed[20];
+   ushort inst;
+
+   for(inst = 0; inst < 65536; inst++) {
+      unparse(unparsed, inst);
+      printf("%s\n", unparsed);
+   }
 
    return 0;
 }

--- a/src/iris/iris.c
+++ b/src/iris/iris.c
@@ -23,7 +23,7 @@ int main() {
 */
 
 int main() {
-   char unparsed[20];
+   char unparsed[100];
    ushort inst;
 
    for(inst = 0; inst < 65535; inst++) {
@@ -283,5 +283,5 @@ void compare(core* proc, instruction inst) {
 
 void error(char* message, int code) {
    fprintf(stderr, "%s\n", message);
-   exit(code);
+   // exit(code);
 }

--- a/src/iris/iris.c
+++ b/src/iris/iris.c
@@ -291,3 +291,5 @@ void error(char* message, int code) {
    fprintf(stderr, "%s\n", message);
    exit(code);
 }
+
+/* vim: set expandtab tabstop=3 shiftwidth=3: */

--- a/src/iris/iris.c
+++ b/src/iris/iris.c
@@ -24,17 +24,19 @@ int main() {
 
 int main() {
    char unparsed[100];
-   ushort insn;
+   datum d;
+   ushort value;
 
-   for(insn = 0; insn < 65535; insn++) {
-      unparse_bitstring(unparsed, insn);
+   for(value = 0; value < 65535; value++) {
+      d.value = value;
+      unparse_bitstring(unparsed, d);
       printf("%s : ", unparsed);
-      unparse(unparsed, insn);
+      unparse(unparsed, d);
       printf("%s\n", unparsed);
    }
-   unparse_bitstring(unparsed, insn);
+   unparse_bitstring(unparsed, d);
    printf("%s : ", unparsed);
-   unparse(unparsed, insn);
+   unparse(unparsed, d);
    printf("%s\n", unparsed);
 
    return 0;

--- a/src/iris/iris.c
+++ b/src/iris/iris.c
@@ -269,6 +269,10 @@ void compare(core* proc, datum inst) {
    }
 }
 
+void irissystem(core* proc, datum j) {
+   /* implement system commands */
+}
+
 void error(char* message, int code) {
    fprintf(stderr, "%s\n", message);
    exit(code);

--- a/src/iris/iris.h
+++ b/src/iris/iris.h
@@ -194,8 +194,7 @@ enum {
    ErrorInvalidArithmeticOperation = 6,
    ErrorGetRegisterOutOfRange = 7,
    ErrorPutRegisterOutOfRange = 8,
-   ErrorRegisterOutOfRange = 9,
-   ErrorInvalidInstructionGroupProvided = 10,
+   ErrorInvalidInstructionGroupProvided = 9,
 };
 void arithmetic(core* proc, datum inst);
 void move(core* proc, datum inst);

--- a/src/iris/iris.h
+++ b/src/iris/iris.h
@@ -148,7 +148,8 @@ enum {
    ErrorInvalidArithmeticOperation = 6,
    ErrorGetRegisterOutOfRange = 7,
    ErrorPutRegisterOutOfRange = 8,
-   ErrorInvalidInstructionGroupProvided = 9,
+   ErrorRegisterOutOfRange = 9,
+   ErrorInvalidInstructionGroupProvided = 10,
 };
 void arithmetic(core* proc, instruction inst);
 void move(core* proc, instruction inst);

--- a/src/iris/mnemonic.c
+++ b/src/iris/mnemonic.c
@@ -37,7 +37,11 @@ const char* jump_mnemonic(ushort insn) {
       case JumpOpUnconditional: return "goto";
       case JumpOpIfTrue:        return "if1";
       case JumpOpIfFalse:       return "if0";
-      case JumpOpIfThenElse:    return "if";
+      case JumpOpIfThenElse:
+         switch(getjumpimmediatemode(insn)) {
+            case JumpOpIfThenElse_TrueFalse: return "if1";
+            case JumpOpIfThenElse_FalseTrue: return "if0";
+         }
       default:                  return "UNKNOWN_JUMP";
    }
 }

--- a/src/iris/mnemonic.c
+++ b/src/iris/mnemonic.c
@@ -50,42 +50,42 @@ const char* compare_mnemonic(ushort insn) {
    switch(getcomparecombinebits(insn)) {
       case CombineBitsOpNil:
          switch(getcompareop(insn)) {
-            case CompareOpEq:                   return "eq"; break;
-            case CompareOpNeq:                  return "ne"; break;
-            case CompareOpLessThan:             return "lt"; break;
-            case CompareOpGreaterThan:          return "gt"; break;
-            case CompareOpLessThanOrEqualTo:    return "le"; break;
-            case CompareOpGreaterThanOrEqualTo: return "ge"; break;
+            case CompareOpEq:                   return "eq";
+            case CompareOpNeq:                  return "ne";
+            case CompareOpLessThan:             return "lt";
+            case CompareOpGreaterThan:          return "gt";
+            case CompareOpLessThanOrEqualTo:    return "le";
+            case CompareOpGreaterThanOrEqualTo: return "ge";
             default:                            return "UNKNOWN_COMPARE";
          }
       case CombineBitsOpAnd:
          switch(getcompareop(insn)) {
-            case CompareOpEq:                   return "and_eq"; break;
-            case CompareOpNeq:                  return "and_ne"; break;
-            case CompareOpLessThan:             return "and_lt"; break;
-            case CompareOpGreaterThan:          return "and_gt"; break;
-            case CompareOpLessThanOrEqualTo:    return "and_le"; break;
-            case CompareOpGreaterThanOrEqualTo: return "and_ge"; break;
+            case CompareOpEq:                   return "and_eq";
+            case CompareOpNeq:                  return "and_ne";
+            case CompareOpLessThan:             return "and_lt";
+            case CompareOpGreaterThan:          return "and_gt";
+            case CompareOpLessThanOrEqualTo:    return "and_le";
+            case CompareOpGreaterThanOrEqualTo: return "and_ge";
             default:                            return "UNKNOWN_COMPARE";
          }
       case CombineBitsOpOr:
          switch(getcompareop(insn)) {
-            case CompareOpEq:                   return "or_eq"; break;
-            case CompareOpNeq:                  return "or_ne"; break;
-            case CompareOpLessThan:             return "or_lt"; break;
-            case CompareOpGreaterThan:          return "or_gt"; break;
-            case CompareOpLessThanOrEqualTo:    return "or_le"; break;
-            case CompareOpGreaterThanOrEqualTo: return "or_ge"; break;
+            case CompareOpEq:                   return "or_eq";
+            case CompareOpNeq:                  return "or_ne";
+            case CompareOpLessThan:             return "or_lt";
+            case CompareOpGreaterThan:          return "or_gt";
+            case CompareOpLessThanOrEqualTo:    return "or_le";
+            case CompareOpGreaterThanOrEqualTo: return "or_ge";
             default:                            return "UNKNOWN_COMPARE";
          }
       case CombineBitsOpXor:
          switch(getcompareop(insn)) {
-            case CompareOpEq:                   return "xor_eq"; break;
-            case CompareOpNeq:                  return "xor_ne"; break;
-            case CompareOpLessThan:             return "xor_lt"; break;
-            case CompareOpGreaterThan:          return "xor_gt"; break;
-            case CompareOpLessThanOrEqualTo:    return "xor_le"; break;
-            case CompareOpGreaterThanOrEqualTo: return "xor_ge"; break;
+            case CompareOpEq:                   return "xor_eq";
+            case CompareOpNeq:                  return "xor_ne";
+            case CompareOpLessThan:             return "xor_lt";
+            case CompareOpGreaterThan:          return "xor_gt";
+            case CompareOpLessThanOrEqualTo:    return "xor_le";
+            case CompareOpGreaterThanOrEqualTo: return "xor_ge";
             default:                            return "UNKNOWN_COMPARE";
          }
       default:                                  return "UNKNOWN_COMPARE";

--- a/src/iris/mnemonic.c
+++ b/src/iris/mnemonic.c
@@ -1,25 +1,6 @@
 #include <string.h>
 #include "mnemonic.h"
 
-char* mnemonic(ushort value) {
-   datum d;
-   instruction i;
-   d.value = value;
-   i.value = d.rest;
-   switch(d.group) {
-      case InstructionGroupArithmetic:
-         return arithmetic_mnemonic(i);
-      case InstructionGroupMove:
-         return move_mnemonic(i);
-      case InstructionGroupJump:
-         return jump_mnemonic(i);
-      case InstructionGroupCompare:
-         return compare_mnemonic(i);
-      default:
-         return "UNASSIGNED_GROUP";
-   }
-}
-
 char* arithmetic_mnemonic(instruction i) {
    switch(i.arithmetic.op) {
       case ArithmeticOpAdd:        return "add";
@@ -30,7 +11,7 @@ char* arithmetic_mnemonic(instruction i) {
       case ArithmeticOpShiftLeft:  return "shl";
       case ArithmeticOpShiftRight: return "shr";
       case ArithmeticOpBinaryAnd:  return "and";
-      case ArithmeticOpBinaryOr:   return "ior";
+      case ArithmeticOpBinaryOr:   return "or";
       case ArithmeticOpBinaryNot:  return "not";
       case ArithmeticOpBinaryXor:  return "xor";
       default:                     return "UNASSIGNED_ARITHMETIC";
@@ -40,7 +21,7 @@ char* arithmetic_mnemonic(instruction i) {
 char* move_mnemonic(instruction i) {
    switch(i.move.op) {
       case MoveOpRegToReg:       return "move";
-      case MoveOpImmediateToReg: return "load";
+      case MoveOpImmediateToReg: return "move";
       case MoveOpRegToAddress:
          switch(i.move.addressmode.accessmode) {
             case AccessModeMoveOpLoad:  return "load";

--- a/src/iris/mnemonic.c
+++ b/src/iris/mnemonic.c
@@ -16,9 +16,7 @@ char* mnemonic(ushort value) {
       case InstructionGroupCompare:
          return compare_mnemonic(i);
       default:
-         error("invalid instruction group provided",
-               ErrorInvalidInstructionGroupProvided);
-         return "lolurmom"; /* suppress compiler warnings */
+         return "UNKNOWN_GROUP";
    }
 }
 
@@ -35,10 +33,7 @@ char* arithmetic_mnemonic(instruction i) {
       case ArithmeticOpBinaryOr:   return "ior";
       case ArithmeticOpBinaryNot:  return "not";
       case ArithmeticOpBinaryXor:  return "xor";
-      default:
-         error("invalid arithmetic operation",
-               ErrorInvalidArithmeticOperation);
-         return "UNKNOWN_ARITHMETIC_OPERATOR";
+      default:                     return "UNKNOWN_ARITHMETIC";
    }
 }
 
@@ -51,10 +46,7 @@ char* move_mnemonic(instruction i) {
             case AccessModeMoveOpLoad:  return "load";
             case AccessModeMoveOpStore: return "store";
          }
-      default:
-         error("invalid move operation conditional type",
-               ErrorInvalidMoveOperationConditionalType);
-         return "UNKNOWN_MOVE_OPERATOR";
+      default:                   return "UNKNOWN_MOVE";
    }
 }
 
@@ -64,10 +56,7 @@ char* jump_mnemonic(instruction i) {
       case JumpOpIfTrue:        return "iftrue";
       case JumpOpIfFalse:       return "iffalse";
       case JumpOpIfThenElse:    return "if";
-      default:
-         error("invalid jump conditional type",
-               ErrorInvalidJumpConditionalType);
-         return "UNKNOWN JUMP OPERATOR";
+      default:                  return "UNKNOWN_JUMP";
    }
 }
 
@@ -79,9 +68,7 @@ char* compare_mnemonic(instruction i) {
       case CombineBitsOpAnd: strcpy(combinebits, "and_"); break;
       case CombineBitsOpOr:  strcpy(combinebits, "or_");  break;
       case CombineBitsOpXor: strcpy(combinebits, "xor_"); break;
-      default:
-         error("invalid compare combine bits", ErrorInvalidCombineBits);
-         return "???";
+      default:               return "UNKNOWN_COMPARE";
    }
 
    switch(i.compare.op) {
@@ -91,8 +78,6 @@ char* compare_mnemonic(instruction i) {
       case CompareOpGreaterThan:          return strcat(combinebits, "gt");
       case CompareOpLessThanOrEqualTo:    return strcat(combinebits, "le");
       case CompareOpGreaterThanOrEqualTo: return strcat(combinebits, "ge");
-      default:
-         error("invalid compare operation", ErrorInvalidCompareOperation);
-         return "UNKNOWN COMPARE OPERATOR";
+      default:                            return "UNKNOWN_COMPARE";
    }
 }

--- a/src/iris/mnemonic.c
+++ b/src/iris/mnemonic.c
@@ -16,7 +16,7 @@ char* mnemonic(ushort value) {
       case InstructionGroupCompare:
          return compare_mnemonic(i);
       default:
-         return "UNKNOWN_GROUP";
+         return "UNASSIGNED_GROUP";
    }
 }
 
@@ -33,7 +33,7 @@ char* arithmetic_mnemonic(instruction i) {
       case ArithmeticOpBinaryOr:   return "ior";
       case ArithmeticOpBinaryNot:  return "not";
       case ArithmeticOpBinaryXor:  return "xor";
-      default:                     return "UNKNOWN_ARITHMETIC";
+      default:                     return "UNASSIGNED_ARITHMETIC";
    }
 }
 

--- a/src/iris/mnemonic.c
+++ b/src/iris/mnemonic.c
@@ -35,8 +35,8 @@ const char* move_mnemonic(ushort insn) {
 const char* jump_mnemonic(ushort insn) {
    switch(getjumpconditional(insn)) {
       case JumpOpUnconditional: return "goto";
-      case JumpOpIfTrue:        return "iftrue";
-      case JumpOpIfFalse:       return "iffalse";
+      case JumpOpIfTrue:        return "if1";
+      case JumpOpIfFalse:       return "if0";
       case JumpOpIfThenElse:    return "if";
       default:                  return "UNKNOWN_JUMP";
    }

--- a/src/iris/mnemonic.c
+++ b/src/iris/mnemonic.c
@@ -1,8 +1,9 @@
 #include <string.h>
+#include "iris.h"
 #include "mnemonic.h"
 
-char* arithmetic_mnemonic(instruction i) {
-   switch(i.arithmetic.op) {
+const char* arithmetic_mnemonic(ushort insn) {
+   switch(getarithmeticop(insn)) {
       case ArithmeticOpAdd:        return "add";
       case ArithmeticOpSub:        return "sub";
       case ArithmeticOpMul:        return "mul";
@@ -18,12 +19,12 @@ char* arithmetic_mnemonic(instruction i) {
    }
 }
 
-char* move_mnemonic(instruction i) {
-   switch(i.move.op) {
+const char* move_mnemonic(ushort insn) {
+   switch(getmoveop(insn)) {
       case MoveOpRegToReg:       return "move";
       case MoveOpImmediateToReg: return "move";
       case MoveOpRegToAddress:
-         switch(i.move.addressmode.accessmode) {
+         switch(getmoveaccessmode(insn)) {
             case AccessModeMoveOpLoad:  return "load";
             case AccessModeMoveOpStore: return "store";
          }
@@ -31,8 +32,8 @@ char* move_mnemonic(instruction i) {
    }
 }
 
-char* jump_mnemonic(instruction i) {
-   switch(i.jump.conditional) {
+const char* jump_mnemonic(ushort insn) {
+   switch(getjumpconditional(insn)) {
       case JumpOpUnconditional: return "goto";
       case JumpOpIfTrue:        return "iftrue";
       case JumpOpIfFalse:       return "iffalse";
@@ -41,25 +42,49 @@ char* jump_mnemonic(instruction i) {
    }
 }
 
-char* compare_mnemonic(instruction i) {
-   char combinebits[5];
-
-   switch(i.compare.combinebits) {
-      case CombineBitsOpNil: strcpy(combinebits, "");     break;
-      case CombineBitsOpAnd: strcpy(combinebits, "and_"); break;
-      case CombineBitsOpOr:  strcpy(combinebits, "or_");  break;
-      case CombineBitsOpXor: strcpy(combinebits, "xor_"); break;
-      default:               return "UNKNOWN_COMPARE";
-   }
-
-   switch(i.compare.op) {
-      case CompareOpEq:                   return strcat(combinebits, "eq");
-      case CompareOpNeq:                  return strcat(combinebits, "ne");
-      case CompareOpLessThan:             return strcat(combinebits, "lt");
-      case CompareOpGreaterThan:          return strcat(combinebits, "gt");
-      case CompareOpLessThanOrEqualTo:    return strcat(combinebits, "le");
-      case CompareOpGreaterThanOrEqualTo: return strcat(combinebits, "ge");
-      default:                            return "UNKNOWN_COMPARE";
+const char* compare_mnemonic(ushort insn) {
+   switch(getcomparecombinebits(insn)) {
+      case CombineBitsOpNil:
+         switch(getcompareop(insn)) {
+            case CompareOpEq:                   return "eq"; break;
+            case CompareOpNeq:                  return "ne"; break;
+            case CompareOpLessThan:             return "lt"; break;
+            case CompareOpGreaterThan:          return "gt"; break;
+            case CompareOpLessThanOrEqualTo:    return "le"; break;
+            case CompareOpGreaterThanOrEqualTo: return "ge"; break;
+            default:                            return "UNKNOWN_COMPARE";
+         }
+      case CombineBitsOpAnd:
+         switch(getcompareop(insn)) {
+            case CompareOpEq:                   return "and_eq"; break;
+            case CompareOpNeq:                  return "and_ne"; break;
+            case CompareOpLessThan:             return "and_lt"; break;
+            case CompareOpGreaterThan:          return "and_gt"; break;
+            case CompareOpLessThanOrEqualTo:    return "and_le"; break;
+            case CompareOpGreaterThanOrEqualTo: return "and_ge"; break;
+            default:                            return "UNKNOWN_COMPARE";
+         }
+      case CombineBitsOpOr:
+         switch(getcompareop(insn)) {
+            case CompareOpEq:                   return "or_eq"; break;
+            case CompareOpNeq:                  return "or_ne"; break;
+            case CompareOpLessThan:             return "or_lt"; break;
+            case CompareOpGreaterThan:          return "or_gt"; break;
+            case CompareOpLessThanOrEqualTo:    return "or_le"; break;
+            case CompareOpGreaterThanOrEqualTo: return "or_ge"; break;
+            default:                            return "UNKNOWN_COMPARE";
+         }
+      case CombineBitsOpXor:
+         switch(getcompareop(insn)) {
+            case CompareOpEq:                   return "xor_eq"; break;
+            case CompareOpNeq:                  return "xor_ne"; break;
+            case CompareOpLessThan:             return "xor_lt"; break;
+            case CompareOpGreaterThan:          return "xor_gt"; break;
+            case CompareOpLessThanOrEqualTo:    return "xor_le"; break;
+            case CompareOpGreaterThanOrEqualTo: return "xor_ge"; break;
+            default:                            return "UNKNOWN_COMPARE";
+         }
+      default:                                  return "UNKNOWN_COMPARE";
    }
 }
 

--- a/src/iris/mnemonic.c
+++ b/src/iris/mnemonic.c
@@ -81,3 +81,5 @@ char* compare_mnemonic(instruction i) {
       default:                            return "UNKNOWN_COMPARE";
    }
 }
+
+/* vim: set expandtab tabstop=3 shiftwidth=3: */

--- a/src/iris/mnemonic.c
+++ b/src/iris/mnemonic.c
@@ -21,8 +21,8 @@ const char* arithmetic_mnemonic(ushort insn) {
 
 const char* move_mnemonic(ushort insn) {
    switch(getmoveop(insn)) {
-      case MoveOpRegToReg:       return "move";
-      case MoveOpImmediateToReg: return "move";
+      case MoveOpRegToReg:       return "load";
+      case MoveOpImmediateToReg: return "load";
       case MoveOpRegToAddress:
          switch(getmoveaccessmode(insn)) {
             case AccessModeMoveOpLoad:  return "load";

--- a/src/iris/mnemonic.c
+++ b/src/iris/mnemonic.c
@@ -45,8 +45,12 @@ char* arithmetic_mnemonic(instruction i) {
 char* move_mnemonic(instruction i) {
    switch(i.move.op) {
       case MoveOpRegToReg:       return "move";
-      case MoveOpImmediateToReg: return "store";
-      case MoveOpRegToAddress:   return "load";
+      case MoveOpImmediateToReg: return "load";
+      case MoveOpRegToAddress:
+         switch(i.move.addressmode.accessmode) {
+            case AccessModeMoveOpLoad:  return "load";
+            case AccessModeMoveOpStore: return "store";
+         }
       default:
          error("invalid move operation conditional type",
                ErrorInvalidMoveOperationConditionalType);

--- a/src/iris/mnemonic.c
+++ b/src/iris/mnemonic.c
@@ -1,0 +1,94 @@
+#include <string.h>
+#include "mnemonic.h"
+
+char* mnemonic(ushort value) {
+   datum d;
+   instruction i;
+   d.value = value;
+   i.value = d.rest;
+   switch(d.group) {
+      case InstructionGroupArithmetic:
+         return arithmetic_mnemonic(i);
+      case InstructionGroupMove:
+         return move_mnemonic(i);
+      case InstructionGroupJump:
+         return jump_mnemonic(i);
+      case InstructionGroupCompare:
+         return compare_mnemonic(i);
+      default:
+         error("invalid instruction group provided",
+               ErrorInvalidInstructionGroupProvided);
+         return "lolurmom"; /* suppress compiler warnings */
+   }
+}
+
+char* arithmetic_mnemonic(instruction i) {
+   switch(i.arithmetic.op) {
+      case ArithmeticOpAdd:        return "add";
+      case ArithmeticOpSub:        return "sub";
+      case ArithmeticOpMul:        return "mul";
+      case ArithmeticOpDiv:        return "div";
+      case ArithmeticOpRem:        return "rem";
+      case ArithmeticOpShiftLeft:  return "shl";
+      case ArithmeticOpShiftRight: return "shr";
+      case ArithmeticOpBinaryAnd:  return "and";
+      case ArithmeticOpBinaryOr:   return "ior";
+      case ArithmeticOpBinaryNot:  return "not";
+      case ArithmeticOpBinaryXor:  return "xor";
+      default:
+         error("invalid arithmetic operation",
+               ErrorInvalidArithmeticOperation);
+         return "UNKNOWN_ARITHMETIC_OPERATOR";
+   }
+}
+
+char* move_mnemonic(instruction i) {
+   switch(i.move.op) {
+      case MoveOpRegToReg:       return "move";
+      case MoveOpImmediateToReg: return "store";
+      case MoveOpRegToAddress:   return "load";
+      default:
+         error("invalid move operation conditional type",
+               ErrorInvalidMoveOperationConditionalType);
+         return "UNKNOWN_MOVE_OPERATOR";
+   }
+}
+
+char* jump_mnemonic(instruction i) {
+   switch(i.jump.conditional) {
+      case JumpOpUnconditional: return "goto";
+      case JumpOpIfTrue:        return "iftrue";
+      case JumpOpIfFalse:       return "iffalse";
+      case JumpOpIfThenElse:    return "if";
+      default:
+         error("invalid jump conditional type",
+               ErrorInvalidJumpConditionalType);
+         return "UNKNOWN JUMP OPERATOR";
+   }
+}
+
+char* compare_mnemonic(instruction i) {
+   char combinebits[5];
+
+   switch(i.compare.combinebits) {
+      case CombineBitsOpNil: strcpy(combinebits, "");     break;
+      case CombineBitsOpAnd: strcpy(combinebits, "and_"); break;
+      case CombineBitsOpOr:  strcpy(combinebits, "or_");  break;
+      case CombineBitsOpXor: strcpy(combinebits, "xor_"); break;
+      default:
+         error("invalid compare combine bits", ErrorInvalidCombineBits);
+         return "???";
+   }
+
+   switch(i.compare.op) {
+      case CompareOpEq:                   return strcat(combinebits, "eq");
+      case CompareOpNeq:                  return strcat(combinebits, "ne");
+      case CompareOpLessThan:             return strcat(combinebits, "lt");
+      case CompareOpGreaterThan:          return strcat(combinebits, "gt");
+      case CompareOpLessThanOrEqualTo:    return strcat(combinebits, "le");
+      case CompareOpGreaterThanOrEqualTo: return strcat(combinebits, "ge");
+      default:
+         error("invalid compare operation", ErrorInvalidCompareOperation);
+         return "UNKNOWN COMPARE OPERATOR";
+   }
+}

--- a/src/iris/mnemonic.h
+++ b/src/iris/mnemonic.h
@@ -1,6 +1,6 @@
 #include "iris.h"
 
-char* arithmetic_mnemonic(instruction i);
-char* move_mnemonic(instruction i);
-char* jump_mnemonic(instruction i);
-char* compare_mnemonic(instruction i);
+const char* arithmetic_mnemonic(ushort insn);
+const char* move_mnemonic(ushort insn);
+const char* jump_mnemonic(ushort insn);
+const char* compare_mnemonic(ushort insn);

--- a/src/iris/mnemonic.h
+++ b/src/iris/mnemonic.h
@@ -1,0 +1,7 @@
+#include "iris.h"
+
+char* mnemonic(ushort value);
+char* arithmetic_mnemonic(instruction i);
+char* move_mnemonic(instruction i);
+char* jump_mnemonic(instruction i);
+char* compare_mnemonic(instruction i);

--- a/src/iris/mnemonic.h
+++ b/src/iris/mnemonic.h
@@ -1,6 +1,5 @@
 #include "iris.h"
 
-char* mnemonic(ushort value);
 char* arithmetic_mnemonic(instruction i);
 char* move_mnemonic(instruction i);
 char* jump_mnemonic(instruction i);

--- a/src/iris/sim.c
+++ b/src/iris/sim.c
@@ -104,7 +104,3 @@ void installprogram(FILE* file) {
       }
    }
 }
-
-void irissystem(core* proc, datum j) {
-   /* implement system commands */
-}

--- a/src/iris/tests/decode.c
+++ b/src/iris/tests/decode.c
@@ -187,5 +187,3 @@ int checkandreport(testcase* test) {
          fieldName, value, result, against, strings[compare]);
    return compare;
 }
-
-void irissystem(core* proc, datum j) { }

--- a/src/iris/tests/mnemonic.c
+++ b/src/iris/tests/mnemonic.c
@@ -7,7 +7,7 @@ int main() {
   ushort insn;
   for(insn = 0; insn < 65535; insn++) {
     switch(getgroup(insn)) {
-      case InstructionGroupArithmetic: 
+      case InstructionGroupArithmetic:
         puts(arithmetic_mnemonic(insn));
         break;
       case InstructionGroupMove:

--- a/src/iris/tests/mnemonic.c
+++ b/src/iris/tests/mnemonic.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../iris.h"
+#include "../mnemonic.h"
+
+int main() {
+  ushort insn;
+  for(insn = 0; insn < 65535; insn++) {
+    switch(getgroup(insn)) {
+      case InstructionGroupArithmetic: 
+        puts(arithmetic_mnemonic(insn));
+        break;
+      case InstructionGroupMove:
+        puts(move_mnemonic(insn));
+        break;
+      case InstructionGroupJump:
+        puts(jump_mnemonic(insn));
+        break;
+      case InstructionGroupCompare:
+        puts(compare_mnemonic(insn));
+        break;
+      default:
+        puts("Unknown instruction group");
+    }
+  }
+  return 0;
+}

--- a/src/iris/tests/unparse.c
+++ b/src/iris/tests/unparse.c
@@ -5,19 +5,17 @@
 
 int main() {
    char unparsed[100];
-   datum d;
-   ushort value;
+   ushort insn;
 
-   for(value = 0; value < 65535; value++) {
-      d.value = value;
-      unparse_bitstring(unparsed, d);
+   for(insn = 0; insn < 65535; insn++) {
+      unparse_bitstring(unparsed, insn);
       printf("%s : ", unparsed);
-      unparse(unparsed, d);
+      unparse(unparsed, insn);
       printf("%s\n", unparsed);
    }
-   unparse_bitstring(unparsed, d);
+   unparse_bitstring(unparsed, insn);
    printf("%s : ", unparsed);
-   unparse(unparsed, d);
+   unparse(unparsed, insn);
    printf("%s\n", unparsed);
 
    return 0;

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -3,10 +3,8 @@
 #include "mnemonic.h"
 #include "unparse.h"
 
-void unparse(char* unparsed, ushort value) {
-   datum d;
+void unparse(char* unparsed, datum d) {
    instruction i;
-   d.value = value;
    i.value = d.rest;
    switch(d.group) {
       case InstructionGroupArithmetic:
@@ -103,9 +101,11 @@ void unparse_compare(char* unparsed, instruction i) {
    sprintf(unparsed, "%s %s %s", insn, reg0, reg1);
 }
 
-void unparse_bitstring(char* unparsed, ushort value) {
+void unparse_bitstring(char* unparsed, datum d) {
    unparsed[16] = '\0';
    int bit;
+   ushort value;
+   value = d.value;
    for (bit = 15; bit >= 0; bit -= 1) {
       unparsed[bit] = (value & 1) + '0';
       value >>= 1;

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -22,8 +22,7 @@ void unparse(char* unparsed, ushort value) {
          unparse_compare(unparsed, i);
          break;
       default:
-         error("invalid instruction group provided",
-               ErrorInvalidInstructionGroupProvided);
+         sprintf(unparsed, "UNASSIGNED INSTRUCTION GROUP");
    }
 }
 
@@ -31,8 +30,7 @@ void unparse_register(char* unparsed, byte index) {
    if(index < RegisterCount) {
       sprintf(unparsed, "r%d", index);
    } else {
-      error("attempted to unparse an out-of-range register",
-            ErrorRegisterOutOfRange);
+      sprintf(unparsed, "INVALID_REGISTER");
    }
 }
 
@@ -51,9 +49,20 @@ void unparse_arithmetic(char* unparsed, instruction i) {
       case ArithmeticOpBinaryNot:
          sprintf(unparsed, "%s %s <- %s", insn, dest, source0);
          break;
-      default:
+      case ArithmeticOpAdd:
+      case ArithmeticOpSub:
+      case ArithmeticOpMul:
+      case ArithmeticOpDiv:
+      case ArithmeticOpRem:
+      case ArithmeticOpShiftLeft:
+      case ArithmeticOpShiftRight:
+      case ArithmeticOpBinaryAnd:
+      case ArithmeticOpBinaryOr:
+      case ArithmeticOpBinaryXor:
          sprintf(unparsed, "%s %s <- %s %s", insn, dest, source0, source1);
          break;
+      default:
+         sprintf(unparsed, "INVALID ARITHMETIC");
    }
 }
 
@@ -86,8 +95,7 @@ void unparse_move(char* unparsed, instruction i) {
          }
          break;
       default:
-         error("invalid move operation conditional type",
-               ErrorInvalidMoveOperationConditionalType);
+         sprintf(unparsed, "INVALID MOVE");
    }
 }
 

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -92,7 +92,15 @@ void unparse_jump(char* unparsed, instruction i) {
 }
 
 void unparse_compare(char* unparsed, instruction i) {
-   sprintf(unparsed, "%s TODO", compare_mnemonic(i));
+   char* insn;
+   char reg0[3];
+   char reg1[3];
+
+   insn = compare_mnemonic(i);
+   unparse_register(reg0, i.compare.reg0);
+   unparse_register(reg1, i.compare.reg1);
+
+   sprintf(unparsed, "%s %s %s", insn, reg0, reg1);
 }
 
 void unparse_bitstring(char* unparsed, ushort value) {

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -3,21 +3,19 @@
 #include "mnemonic.h"
 #include "unparse.h"
 
-void unparse(char* unparsed, datum d) {
-   instruction i;
-   i.value = d.rest;
-   switch(d.group) {
+void unparse(char* unparsed, ushort insn) {
+   switch(getgroup(insn)) {
       case InstructionGroupArithmetic:
-         unparse_arithmetic(unparsed, i);
+         unparse_arithmetic(unparsed, insn);
          break;
       case InstructionGroupMove:
-         unparse_move(unparsed, i);
+         unparse_move(unparsed, insn);
          break;
       case InstructionGroupJump:
-         unparse_jump(unparsed, i);
+         unparse_jump(unparsed, insn);
          break;
       case InstructionGroupCompare:
-         unparse_compare(unparsed, i);
+         unparse_compare(unparsed, insn);
          break;
       default:
          sprintf(unparsed, "UNASSIGNED INSTRUCTION GROUP");
@@ -32,52 +30,52 @@ void unparse_register(char* unparsed, byte index) {
    }
 }
 
-void unparse_arithmetic(char* unparsed, instruction i) {
-   char* insn;
+void unparse_arithmetic(char* unparsed, ushort insn) {
+   const char* op;
    char dest[3];
    char source0[3];
    char source1[3];
 
-   insn = arithmetic_mnemonic(i);
-   unparse_register(dest, i.arithmetic.dest);
-   unparse_register(source0, i.arithmetic.source0);
-   unparse_register(source1, i.arithmetic.source1);
+   op = arithmetic_mnemonic(insn);
+   unparse_register(dest, getarithmeticdest(insn));
+   unparse_register(source0, getarithmeticsource0(insn));
+   unparse_register(source1, getarithmeticsource1(insn));
 
-   switch(i.arithmetic.op) {
+   switch(getarithmeticop(insn)) {
       case ArithmeticOpBinaryNot:
-         sprintf(unparsed, "%s %s <- %s", insn, dest, source0);
+         sprintf(unparsed, "%s %s <- %s", op, dest, source0);
          break;
       default:
-         sprintf(unparsed, "%s %s <- %s %s", insn, dest, source0, source1);
+         sprintf(unparsed, "%s %s <- %s %s", op, dest, source0, source1);
    }
 }
 
-void unparse_move(char* unparsed, instruction i) {
-   char* insn;
+void unparse_move(char* unparsed, ushort insn) {
+   const char* op;
    char reg0[3];
    char reg1[3];
    char reg2[3];
 
-   insn = move_mnemonic(i);
+   op = move_mnemonic(insn);
 
-   switch(i.move.op) {
+   switch(getmoveop(insn)) {
       case MoveOpRegToReg:
-         unparse_register(reg0, i.move.reg0);
-         unparse_register(reg1, i.move.reg1);
-         sprintf(unparsed, "%s %s <- %s", insn, reg0, reg1);
+         unparse_register(reg0, getmovereg0(insn));
+         unparse_register(reg1, getmovereg1(insn));
+         sprintf(unparsed, "%s %s <- %s", op, reg0, reg1);
          break;
       case MoveOpImmediateToReg:
-         unparse_register(reg0, i.move.reg0);
-         sprintf(unparsed, "%s %s <- %d", insn, reg0, i.move.immediate);
+         unparse_register(reg0, getmovereg0(insn));
+         sprintf(unparsed, "%s %s <- %d", op, reg0, getmoveimmediate(insn));
          break;
       case MoveOpRegToAddress:
-         unparse_register(reg0, i.move.reg0);
-         unparse_register(reg1, i.move.addressmode.reg1);
-         unparse_register(reg2, i.move.addressmode.reg2);
-         if(i.move.addressmode.accessmode == AccessModeMoveOpLoad) {
-            sprintf(unparsed, "%s %s <- %s %s", insn, reg0, reg1, reg2);
+         unparse_register(reg0, getmovereg0(insn));
+         unparse_register(reg1, getmovereg1(insn));
+         unparse_register(reg2, getmovereg2(insn));
+         if(getmoveaccessmode(insn) == AccessModeMoveOpLoad) {
+            sprintf(unparsed, "%s %s <- %s %s", op, reg0, reg1, reg2);
          } else {
-            sprintf(unparsed, "%s %s -> %s %s", insn, reg0, reg1, reg2);
+            sprintf(unparsed, "%s %s -> %s %s", op, reg0, reg1, reg2);
          }
          break;
       default:
@@ -85,30 +83,28 @@ void unparse_move(char* unparsed, instruction i) {
    }
 }
 
-void unparse_jump(char* unparsed, instruction i) {
-   sprintf(unparsed, "%s TODO", jump_mnemonic(i));
+void unparse_jump(char* unparsed, ushort insn) {
+   sprintf(unparsed, "%s TODO", jump_mnemonic(insn));
 }
 
-void unparse_compare(char* unparsed, instruction i) {
-   char* insn;
+void unparse_compare(char* unparsed, ushort insn) {
+   const char* op;
    char reg0[3];
    char reg1[3];
 
-   insn = compare_mnemonic(i);
-   unparse_register(reg0, i.compare.reg0);
-   unparse_register(reg1, i.compare.reg1);
+   op = compare_mnemonic(insn);
+   unparse_register(reg0, getcomparereg0(insn));
+   unparse_register(reg1, getcomparereg1(insn));
 
-   sprintf(unparsed, "%s %s %s", insn, reg0, reg1);
+   sprintf(unparsed, "%s %s %s", op, reg0, reg1);
 }
 
-void unparse_bitstring(char* unparsed, datum d) {
+void unparse_bitstring(char* unparsed, ushort insn) {
    unparsed[16] = '\0';
    int bit;
-   ushort value;
-   value = d.value;
    for (bit = 15; bit >= 0; bit -= 1) {
-      unparsed[bit] = (value & 1) + '0';
-      value >>= 1;
+      unparsed[bit] = (insn & 1) + '0';
+      insn >>= 1;
    }
 }
 

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -84,7 +84,70 @@ void unparse_move(char* unparsed, ushort insn) {
 }
 
 void unparse_jump(char* unparsed, ushort insn) {
+   byte is_normal;
+   is_normal = getjumpconditional(insn) != JumpOpIfThenElse;
+   if(is_normal == 1) {
+      unparse_normal_jump(unparsed, insn);
+   } else {
+      unparse_if_then_else(unparsed, insn);
+   }
+}
+
+void unparse_normal_jump(char* unparsed, ushort insn) {
+   const char* op;
+   char reg0[3];
+   char reg1[3];
+   byte is_relative;
+   byte is_immediate;
+   byte is_signed;
+
+   op = jump_mnemonic(insn);
+   is_relative = getjumpdistance(insn) == JumpDistanceShort;
+   is_immediate = getjumpimmediatemode(insn) == 1;
+   is_signed = getjumpsignedmode(insn) == 1;
+
+   if(is_relative && is_immediate && is_signed == 1) {
+      sprintf(unparsed, "%s %d", op, (schar) getjumpimmediate(insn));
+   } else if(is_relative && is_immediate && !is_signed == 1) {
+      sprintf(unparsed, "%s %d", op, getjumpimmediate(insn));
+   } else if(is_relative && !is_immediate && is_signed == 1) {
+      unparse_register(reg1, getjumpreg1(insn));
+      sprintf(unparsed, "%s $%s", op, reg1);
+   } else if(is_relative && !is_immediate && !is_signed == 1) {
+      unparse_register(reg1, getjumpreg1(insn));
+      sprintf(unparsed, "%s %s", op, reg1);
+   } else if(!is_relative) {
+      unparse_register(reg0, getjumpreg0(insn));
+      unparse_register(reg1, getjumpreg1(insn));
+      sprintf(unparsed, "%s %s %s", op, reg0, reg1);
+   } else {
+      sprintf(unparsed, "INVALID JUMP");
+   }
+}
+
+void unparse_if_then_else(char* unparsed, ushort insn) {
    sprintf(unparsed, "%s TODO", jump_mnemonic(insn));
+   /*
+   // now this is going to get a tad confusing
+   if(immediatemode == JumpOpIfThenElse_TrueFalse) {
+   } else if(immediatemode == JumpOpIfThenElse_FalseTrue) {
+   } else {
+      // this should never ever get executed!
+   }
+   if(shouldJump == 1) {
+      if(getjumpsignedmode(inst) == 1) {
+         proc->pc += (schar)getregister(proc, getjumpreg0(inst));
+      } else {
+         proc->pc += getregister(proc, getjumpreg0(inst));
+      }
+   } else {
+      if(getjumpreg1issigned(inst) == 1) {
+         proc->pc += (schar)getregister(proc, getjumpreg1(inst));
+      } else {
+         proc->pc += getregister(proc, getjumpreg1(inst));
+      }
+   }
+   */
 }
 
 void unparse_compare(char* unparsed, ushort insn) {

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include "mnemonic.h"
 #include "unparse.h"
 
 void unparse(char* unparsed, ushort value) {
@@ -11,15 +12,15 @@ void unparse(char* unparsed, ushort value) {
       case InstructionGroupArithmetic:
          unparse_arithmetic(unparsed, i);
          break;
-         // case InstructionGroupMove:
-         //    unparse_move(unparsed, i);
-         //    break;
-         // case InstructionGroupJump:
-         //    unparse_jump(unparsed, i);
-         //    break;
-         // case InstructionGroupCompare:
-         //    unparse_compare(unparsed, i);
-         //    break;
+      case InstructionGroupMove:
+         unparse_move(unparsed, i);
+         break;
+      case InstructionGroupJump:
+         unparse_jump(unparsed, i);
+         break;
+      case InstructionGroupCompare:
+         unparse_compare(unparsed, i);
+         break;
       default:
          error("invalid instruction group provided",
                ErrorInvalidInstructionGroupProvided);
@@ -36,50 +37,34 @@ void unparse_register(char* unparsed, byte index) {
 }
 
 void unparse_arithmetic(char* unparsed, instruction i) {
+   char* insn;
    char dest[3];
    char source0[3];
    char source1[3];
 
+   insn = arithmetic_mnemonic(i);
    unparse_register(dest, i.arithmetic.dest);
    unparse_register(source0, i.arithmetic.source0);
    unparse_register(source1, i.arithmetic.source1);
 
    switch(i.arithmetic.op) {
-      case ArithmeticOpAdd:
-         sprintf(unparsed, "add %s <- %s %s", dest, source0, source1);
-         break;
-      case ArithmeticOpSub:
-         sprintf(unparsed, "sub %s <- %s %s", dest, source0, source1);
-         break;
-      case ArithmeticOpMul:
-         sprintf(unparsed, "mul %s <- %s %s", dest, source0, source1);
-         break;
-      case ArithmeticOpDiv:
-         sprintf(unparsed, "div %s <- %s %s", dest, source0, source1);
-         break;
-      case ArithmeticOpRem:
-         sprintf(unparsed, "rem %s <- %s %s", dest, source0, source1);
-         break;
-      case ArithmeticOpShiftLeft:
-         sprintf(unparsed, "shl %s <- %s %s", dest, source0, source1);
-         break;
-      case ArithmeticOpShiftRight:
-         sprintf(unparsed, "shr %s <- %s %s", dest, source0, source1);
-         break;
-      case ArithmeticOpBinaryAnd:
-         sprintf(unparsed, "and %s <- %s %s", dest, source0, source1);
-         break;
-      case ArithmeticOpBinaryOr:
-         sprintf(unparsed, "or %s <- %s %s", dest, source0, source1);
-         break;
       case ArithmeticOpBinaryNot:
-         sprintf(unparsed, "not %s <- %s", dest, source0);
-         break;
-      case ArithmeticOpBinaryXor:
-         sprintf(unparsed, "xor %s <- %s %s", dest, source0, source1);
+         sprintf(unparsed, "%s %s <- %s", insn, dest, source0);
          break;
       default:
-         error("invalid arithmetic operation",
-               ErrorInvalidArithmeticOperation);
+         sprintf(unparsed, "%s %s <- %s %s", insn, dest, source0, source1);
+         break;
    }
+}
+
+void unparse_move(char* unparsed, instruction i) {
+   sprintf(unparsed, "%s TODO", move_mnemonic(i));
+}
+
+void unparse_jump(char* unparsed, instruction i) {
+   sprintf(unparsed, "%s TODO", jump_mnemonic(i));
+}
+
+void unparse_compare(char* unparsed, instruction i) {
+   sprintf(unparsed, "%s TODO", compare_mnemonic(i));
 }

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -111,3 +111,5 @@ void unparse_bitstring(char* unparsed, ushort value) {
       value >>= 1;
    }
 }
+
+/* vim: set expandtab tabstop=3 shiftwidth=3: */

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -1,0 +1,85 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include "unparse.h"
+
+void unparse(char* unparsed, ushort value) {
+   datum d;
+   instruction i;
+   d.value = value;
+   i.value = d.rest;
+   switch(d.group) {
+      case InstructionGroupArithmetic:
+         unparse_arithmetic(unparsed, i);
+         break;
+         // case InstructionGroupMove:
+         //    unparse_move(unparsed, i);
+         //    break;
+         // case InstructionGroupJump:
+         //    unparse_jump(unparsed, i);
+         //    break;
+         // case InstructionGroupCompare:
+         //    unparse_compare(unparsed, i);
+         //    break;
+      default:
+         error("invalid instruction group provided",
+               ErrorInvalidInstructionGroupProvided);
+   }
+}
+
+void unparse_register(char* unparsed, byte index) {
+   if(index < RegisterCount) {
+      sprintf(unparsed, "r%d", index);
+   } else {
+      error("attempted to unparse an out-of-range register",
+            ErrorRegisterOutOfRange);
+   }
+}
+
+void unparse_arithmetic(char* unparsed, instruction i) {
+   char dest[3];
+   char source0[3];
+   char source1[3];
+
+   unparse_register(dest, i.arithmetic.dest);
+   unparse_register(source0, i.arithmetic.source0);
+   unparse_register(source1, i.arithmetic.source1);
+
+   switch(i.arithmetic.op) {
+      case ArithmeticOpAdd:
+         sprintf(unparsed, "add %s <- %s %s", dest, source0, source1);
+         break;
+      case ArithmeticOpSub:
+         sprintf(unparsed, "sub %s <- %s %s", dest, source0, source1);
+         break;
+      case ArithmeticOpMul:
+         sprintf(unparsed, "mul %s <- %s %s", dest, source0, source1);
+         break;
+      case ArithmeticOpDiv:
+         sprintf(unparsed, "div %s <- %s %s", dest, source0, source1);
+         break;
+      case ArithmeticOpRem:
+         sprintf(unparsed, "rem %s <- %s %s", dest, source0, source1);
+         break;
+      case ArithmeticOpShiftLeft:
+         sprintf(unparsed, "shl %s <- %s %s", dest, source0, source1);
+         break;
+      case ArithmeticOpShiftRight:
+         sprintf(unparsed, "shr %s <- %s %s", dest, source0, source1);
+         break;
+      case ArithmeticOpBinaryAnd:
+         sprintf(unparsed, "and %s <- %s %s", dest, source0, source1);
+         break;
+      case ArithmeticOpBinaryOr:
+         sprintf(unparsed, "or %s <- %s %s", dest, source0, source1);
+         break;
+      case ArithmeticOpBinaryNot:
+         sprintf(unparsed, "not %s <- %s", dest, source0);
+         break;
+      case ArithmeticOpBinaryXor:
+         sprintf(unparsed, "xor %s <- %s %s", dest, source0, source1);
+         break;
+      default:
+         error("invalid arithmetic operation",
+               ErrorInvalidArithmeticOperation);
+   }
+}

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -58,7 +58,37 @@ void unparse_arithmetic(char* unparsed, instruction i) {
 }
 
 void unparse_move(char* unparsed, instruction i) {
-   sprintf(unparsed, "%s TODO", move_mnemonic(i));
+   char* insn;
+   char reg0[3];
+   char reg1[3];
+   char reg2[3];
+
+   insn = move_mnemonic(i);
+
+   switch(i.move.op) {
+      case MoveOpRegToReg:
+         unparse_register(reg0, i.move.reg0);
+         unparse_register(reg1, i.move.reg1);
+         sprintf(unparsed, "%s %s <- %s", insn, reg0, reg1);
+         break;
+      case MoveOpImmediateToReg:
+         unparse_register(reg0, i.move.reg0);
+         sprintf(unparsed, "%s %s <- %d", insn, reg0, i.move.immediate);
+         break;
+      case MoveOpRegToAddress:
+         unparse_register(reg0, i.move.reg0);
+         unparse_register(reg1, i.move.addressmode.reg1);
+         unparse_register(reg2, i.move.addressmode.reg2);
+         if(i.move.addressmode.accessmode == AccessModeMoveOpLoad) {
+            sprintf(unparsed, "%s %s <- %s %s", insn, reg0, reg1, reg2);
+         } else {
+            sprintf(unparsed, "%s %s -> %s %s", insn, reg0, reg1, reg2);
+         }
+         break;
+      default:
+         error("invalid move operation conditional type",
+               ErrorInvalidMoveOperationConditionalType);
+   }
 }
 
 void unparse_jump(char* unparsed, instruction i) {

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -98,3 +98,12 @@ void unparse_jump(char* unparsed, instruction i) {
 void unparse_compare(char* unparsed, instruction i) {
    sprintf(unparsed, "%s TODO", compare_mnemonic(i));
 }
+
+void unparse_bitstring(char* unparsed, ushort value) {
+   unparsed[16] = '\0';
+   int bit;
+   for (bit = 15; bit >= 0; bit -= 1) {
+      unparsed[bit] = (value & 1) + '0';
+      value >>= 1;
+   }
+}

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -43,10 +43,10 @@ void unparse_arithmetic(char* unparsed, ushort insn) {
 
    switch(getarithmeticop(insn)) {
       case ArithmeticOpBinaryNot:
-         sprintf(unparsed, "%s %s <- %s", op, dest, source0);
+         sprintf(unparsed, "%s %s %s", op, dest, source0);
          break;
       default:
-         sprintf(unparsed, "%s %s <- %s %s", op, dest, source0, source1);
+         sprintf(unparsed, "%s %s %s %s", op, dest, source0, source1);
    }
 }
 
@@ -62,21 +62,17 @@ void unparse_move(char* unparsed, ushort insn) {
       case MoveOpRegToReg:
          unparse_register(reg0, getmovereg0(insn));
          unparse_register(reg1, getmovereg1(insn));
-         sprintf(unparsed, "%s %s <- %s", op, reg0, reg1);
+         sprintf(unparsed, "%s %s %s", op, reg0, reg1);
          break;
       case MoveOpImmediateToReg:
          unparse_register(reg0, getmovereg0(insn));
-         sprintf(unparsed, "%s %s <- %d", op, reg0, getmoveimmediate(insn));
+         sprintf(unparsed, "%s %s %d", op, reg0, getmoveimmediate(insn));
          break;
       case MoveOpRegToAddress:
          unparse_register(reg0, getmovereg0(insn));
          unparse_register(reg1, getmovereg1(insn));
          unparse_register(reg2, getmovereg2(insn));
-         if(getmoveaccessmode(insn) == AccessModeMoveOpLoad) {
-            sprintf(unparsed, "%s %s <- %s %s", op, reg0, reg1, reg2);
-         } else {
-            sprintf(unparsed, "%s %s -> %s %s", op, reg0, reg1, reg2);
-         }
+         sprintf(unparsed, "%s %s %s:%s", op, reg0, reg1, reg2);
          break;
       default:
          sprintf(unparsed, "INVALID MOVE");

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -119,35 +119,36 @@ void unparse_normal_jump(char* unparsed, ushort insn) {
    } else if(!is_relative) {
       unparse_register(reg0, getjumpreg0(insn));
       unparse_register(reg1, getjumpreg1(insn));
-      sprintf(unparsed, "%s %s %s", op, reg0, reg1);
+      sprintf(unparsed, "%s %s:%s", op, reg0, reg1);
    } else {
       sprintf(unparsed, "INVALID JUMP");
    }
 }
 
 void unparse_if_then_else(char* unparsed, ushort insn) {
-   sprintf(unparsed, "%s TODO", jump_mnemonic(insn));
-   /*
-   // now this is going to get a tad confusing
-   if(immediatemode == JumpOpIfThenElse_TrueFalse) {
-   } else if(immediatemode == JumpOpIfThenElse_FalseTrue) {
+   const char* op;
+   char reg0[3];
+   char reg1[3];
+   byte reg0_is_signed;
+   byte reg1_is_signed;
+
+   op = jump_mnemonic(insn);
+   unparse_register(reg0, getjumpreg0(insn));
+   unparse_register(reg1, getjumpreg1(insn));
+   reg0_is_signed = getjumpsignedmode(insn) == 1;
+   reg1_is_signed = getjumpreg1issigned(insn) == 1;
+
+   if(reg0_is_signed && reg1_is_signed == 1) {
+      sprintf(unparsed, "%s $%s $%s", op, reg0, reg1);
+   } else if(reg0_is_signed && !reg1_is_signed == 1) {
+      sprintf(unparsed, "%s $%s %s", op, reg0, reg1);
+   } else if(!reg0_is_signed && reg1_is_signed == 1) {
+      sprintf(unparsed, "%s %s $%s", op, reg0, reg1);
+   } else if(!reg0_is_signed && !reg1_is_signed == 1) {
+      sprintf(unparsed, "%s %s %s", op, reg0, reg1);
    } else {
-      // this should never ever get executed!
+      sprintf(unparsed, "INVALID JUMP");
    }
-   if(shouldJump == 1) {
-      if(getjumpsignedmode(inst) == 1) {
-         proc->pc += (schar)getregister(proc, getjumpreg0(inst));
-      } else {
-         proc->pc += getregister(proc, getjumpreg0(inst));
-      }
-   } else {
-      if(getjumpreg1issigned(inst) == 1) {
-         proc->pc += (schar)getregister(proc, getjumpreg1(inst));
-      } else {
-         proc->pc += getregister(proc, getjumpreg1(inst));
-      }
-   }
-   */
 }
 
 void unparse_compare(char* unparsed, ushort insn) {

--- a/src/iris/unparse.c
+++ b/src/iris/unparse.c
@@ -49,20 +49,8 @@ void unparse_arithmetic(char* unparsed, instruction i) {
       case ArithmeticOpBinaryNot:
          sprintf(unparsed, "%s %s <- %s", insn, dest, source0);
          break;
-      case ArithmeticOpAdd:
-      case ArithmeticOpSub:
-      case ArithmeticOpMul:
-      case ArithmeticOpDiv:
-      case ArithmeticOpRem:
-      case ArithmeticOpShiftLeft:
-      case ArithmeticOpShiftRight:
-      case ArithmeticOpBinaryAnd:
-      case ArithmeticOpBinaryOr:
-      case ArithmeticOpBinaryXor:
-         sprintf(unparsed, "%s %s <- %s %s", insn, dest, source0, source1);
-         break;
       default:
-         sprintf(unparsed, "INVALID ARITHMETIC");
+         sprintf(unparsed, "%s %s <- %s %s", insn, dest, source0, source1);
    }
 }
 

--- a/src/iris/unparse.h
+++ b/src/iris/unparse.h
@@ -1,9 +1,9 @@
 #include "iris.h"
 
-void unparse(char* unparsed, datum d);
+void unparse(char* unparsed, ushort insn);
 void unparse_register(char* unparsed, byte index);
-void unparse_arithmetic(char* unparsed, instruction i);
-void unparse_move(char* unparsed, instruction i);
-void unparse_jump(char* unparsed, instruction i);
-void unparse_compare(char* unparsed, instruction i);
-void unparse_bitstring(char* bits, datum d);
+void unparse_arithmetic(char* unparsed, ushort insn);
+void unparse_move(char* unparsed, ushort insn);
+void unparse_jump(char* unparsed, ushort insn);
+void unparse_compare(char* unparsed, ushort insn);
+void unparse_bitstring(char* bits, ushort insn);

--- a/src/iris/unparse.h
+++ b/src/iris/unparse.h
@@ -1,9 +1,9 @@
 #include "iris.h"
 
-void unparse(char* unparsed, ushort value);
+void unparse(char* unparsed, datum d);
 void unparse_register(char* unparsed, byte index);
 void unparse_arithmetic(char* unparsed, instruction i);
 void unparse_move(char* unparsed, instruction i);
 void unparse_jump(char* unparsed, instruction i);
 void unparse_compare(char* unparsed, instruction i);
-void unparse_bitstring(char* bits, ushort value);
+void unparse_bitstring(char* bits, datum d);

--- a/src/iris/unparse.h
+++ b/src/iris/unparse.h
@@ -1,0 +1,5 @@
+#include "iris.h"
+
+void unparse(char* unparsed, ushort value);
+void unparse_register(char* unparsed, byte index);
+void unparse_arithmetic(char* unparsed, instruction i);

--- a/src/iris/unparse.h
+++ b/src/iris/unparse.h
@@ -3,3 +3,6 @@
 void unparse(char* unparsed, ushort value);
 void unparse_register(char* unparsed, byte index);
 void unparse_arithmetic(char* unparsed, instruction i);
+void unparse_move(char* unparsed, instruction i);
+void unparse_jump(char* unparsed, instruction i);
+void unparse_compare(char* unparsed, instruction i);

--- a/src/iris/unparse.h
+++ b/src/iris/unparse.h
@@ -6,3 +6,4 @@ void unparse_arithmetic(char* unparsed, instruction i);
 void unparse_move(char* unparsed, instruction i);
 void unparse_jump(char* unparsed, instruction i);
 void unparse_compare(char* unparsed, instruction i);
+void unparse_bitstring(char* bits, ushort value);

--- a/src/iris/unparse.h
+++ b/src/iris/unparse.h
@@ -5,5 +5,7 @@ void unparse_register(char* unparsed, byte index);
 void unparse_arithmetic(char* unparsed, ushort insn);
 void unparse_move(char* unparsed, ushort insn);
 void unparse_jump(char* unparsed, ushort insn);
+void unparse_normal_jump(char* unparsed, ushort insn);
+void unparse_if_then_else(char* unparsed, ushort insn);
 void unparse_compare(char* unparsed, ushort insn);
 void unparse_bitstring(char* bits, ushort insn);


### PR DESCRIPTION
OK, so there's a lot going on in this pull request.

High-level feature: `void unparse(char*, ushort)` takes in an instruction and will write a human-friendly string representation.  The obvious gotcha here is, of course, that the instruction set isn't really defined, as per issue #4.  I just took a crack at it, and tried to write the code modularly enough that you can swap out the little details:
- `mnemonic.c` stores the actual instruction mnemonics (`add`, `load`, etc.).  It's essentially a bunch of `switch` statements around `const char*` return values, so it's easy to swap out different mnemonics you might prefer.
- `unparse.c` does the work of stringing together the whole instruction, with the help of `mnemonic.c`.  It's slightly hairier, but adopts a few simple syntactic conventions that should be easy to change:
  - Immediate values are represented in the raw; if signed and negative, they'll have negative signs (duh).
  - Registers are represented as `r<n>`, where `<n>` is a number `0`-`7`.
  - Signed registers are spelled `$r<n>`.
  - Two registers used as one address are written with a colon like `r0:r1`.

I reused certain mnemonics where I _think_ the above syntax rules make the "underlying" instruction unambiguous.  E.g., register-to-register moves look like `load r0 r0`, but immediate-to-register moves look like `load r0 0`.

To support the above, a few other things changed.  On the minor end, I added Vim modelines, because you seem to use 3 spaces of indentation and I was sick of being caught off guard with my `shiftwidth=2`.  More major is the `Makefile` (which is what was giving me the most merge conflicts):
- It uses wildcards now, so you don't have to manually add rules.
- `make iris` builds all top-level files along with `sim.c`, since it's the top-level file with the `main()` function.
- I moved all tests to a `tests/` directory.  Each `.c` file in there should define a `main()` function, so that the next change works...
- `make test_blah` will compile `tests/blah.c` for the `main()` function _instead_ of `sim.c`.

Bringing it all together, I'd love if you could peruse the output of `make test_unparse && ./iris` to make sure (a) it works and (b) the output makes sense.

I welcome your feedback!  Let me know if there's anything I should change.
